### PR TITLE
fix: 그래프 줌인/아웃 구현 완료

### DIFF
--- a/src/NetworkChart.js
+++ b/src/NetworkChart.js
@@ -26,7 +26,13 @@ const NetworkChart = ({ data }) => {
       .domain([0, d3.max(nodes, d => d.degree)]) // degree 값의 범위
       .range([15, 30]); // 최소 15, 최대 30 크기
 
-    // 시뮬레이션 설정
+    // 링크 거리 초기값
+    const baseDistance = 150;
+
+    // D3 시뮬레이션 설정
+    const linkForce = d3.forceLink(edges).id(d => d.id).distance(baseDistance).strength(0.2);
+
+    // D3 시뮬레이션 설정
     const simulation = d3.forceSimulation(nodes)
       .force("link", d3.forceLink(edges).id(d => d.id).distance(150).strength(0.2)) // 약한 링크 장력
       .force("charge", d3.forceManyBody()
@@ -34,7 +40,7 @@ const NetworkChart = ({ data }) => {
         .distanceMin(20) // 최소 거리 증가
         .distanceMax(500) // 최대 거리 증가
       )
-      .force("center", d3.forceCenter(width / 2, height / 2)) // 중심 위치 유지
+      .force("center", d3.forceCenter(width / 2 - 200, height / 2 + 30)) // 중심 위치 유지
       .force("collision", d3.forceCollide().radius(d => sizeScale(d.degree) + 10)) // 충돌 반경 증가
       .force("x", d3.forceX(width / 2).strength(0.05)) // 중심 복귀 강도 증가
       .force("y", d3.forceY(height / 2).strength(0.05)) // 중심 복귀 강도 증가
@@ -51,42 +57,12 @@ const NetworkChart = ({ data }) => {
       .style("height", "auto");
     svg.selectAll("*").remove();
 
-    // SVG 상단에 React 스타일 컴포넌트 렌더링
-    svg.append("foreignObject")
-      .attr("x","30%") // 가운데 정렬 (컴포넌트의 너비를 고려)
-      .attr("y", 15) // 상단 위치
-      .attr("width", 220) // 컴포넌트 너비
-      .attr("height", 50) // 컴포넌트 높이
-      .html(`
-        <div style="
-          position: relative;
-          background-color: #5C469C;
-          color: #fff;
-          padding: 10px 20px;
-          border-radius: 12px;
-          box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-          font-family: 'Arial', sans-serif;
-          font-size: 14px;
-          text-align: center;
-          line-height: 1.5;
-        ">
-          📍 Nodes: ${data.nodes.length} | 🕸️ Edges: ${data.edges.length}
-        </div>
-      `);
-
-    // 줌 기능 설정
-    const zoom = d3.zoom()
-      .scaleExtent([1, 10]) // 최소 1배, 최대 10배 줌 가능
-      .translateExtent([[0, 0], [width, height]]) // 이동 가능한 범위 설정
-      .on("zoom", (event) => {
-        svg.attr("transform", event.transform); // 줌 변환 적용
-      });
-
-    // SVG 요소에 줌 기능 적용
-    svg.call(zoom);
+    // 그래프 그룹 생성
+    const graphGroup = svg.append("g");
 
     // 링크 요소 추가
-    const edge = svg.append("g")
+    const edge = graphGroup.append("g")
+      // svg.append("g")
       .attr("stroke", "#999")
       .attr("stroke-opacity", 0.6)
       .selectAll("line")
@@ -106,7 +82,8 @@ const NetworkChart = ({ data }) => {
       .style("font-size", "12px");
 
     // 노드 그룹 생성 (노드와 텍스트를 함께 포함)
-    const nodeGroup = svg.append("g")
+    const nodeGroup = graphGroup.append("g")
+      // svg.append("g")
       .selectAll("g")
       .data(nodes)
       .join("g")
@@ -127,7 +104,7 @@ const NetworkChart = ({ data }) => {
         .on("end", dragended));
 
     // 노드 원(circle)과 텍스트 추가
-    nodeGroup.append("circle")
+    const circles = nodeGroup.append("circle")
       .attr("r", d => sizeScale(d.degree)) // degree를 기준으로 크기 설정
       .attr("fill", d => color(d.type)) // 노드 색상 설정
       .attr("stroke", "#fff")
@@ -140,6 +117,16 @@ const NetworkChart = ({ data }) => {
       .style("font-weight", "bold") // 텍스트를 볼드체로 설정
       .style("fill", "#333")
       .text(d => d.id);
+
+    // 줌 기능 설정
+    const zoom = d3.zoom()
+      .scaleExtent([0.5, 10]) // 최소 0.5배, 최대 10배 줌 가능
+      .on("zoom", (event) => {
+        svg.select("g").attr("transform", event.transform); // 마우스 위치 기준으로 변환
+      });
+
+    // SVG 요소에 줌 기능 적용
+    svg.call(zoom);
 
     // tick 이벤트에서 요소 위치 업데이트
     function ticked() {
@@ -172,6 +159,29 @@ const NetworkChart = ({ data }) => {
       event.subject.fx = null;
       event.subject.fy = null;
     }
+
+    // SVG 상단에 React 스타일 컴포넌트 렌더링
+    svg.append("foreignObject")
+      .attr("x","30%") // 가운데 정렬 (컴포넌트의 너비를 고려)
+      .attr("y", 15) // 상단 위치
+      .attr("width", 200) // 컴포넌트 너비
+      .attr("height", 50) // 컴포넌트 높이
+      .html(`
+        <div style="
+          position: relative;
+          background-color: #5C469C;
+          color: #fff;
+          padding: 10px 20px;
+          border-radius: 12px;
+          box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+          font-family: 'Arial', sans-serif;
+          font-size: 14px;
+          text-align: center;
+          line-height: 1.5;
+        ">
+          Nodes: ${data.nodes.length} | Edges: ${data.edges.length}
+        </div>
+      `);
 
     return () => {
       simulation.stop();


### PR DESCRIPTION
<img width="1457" alt="스크린샷 2024-11-26 20 03 16" src="https://github.com/user-attachments/assets/7fde7a61-a396-4c62-a07f-af77ff667f4f">

## ⚠️ **크롬에서 실행할 것!**

- [x] 그래프 줌인/아웃 구현
- [x] 상단 노드/엣지 개수 출력 컴포넌트 위치 재배치
- [x] 상단 노드/엣지 개수 출력 컴포넌트 렌더링 순서 재배치

<hr>

### 왜 크롬에서 실행시켜야되나요? (-> 파이어폭스에서 줌인 오류나요!)
1. 렌더링 엔진 차이
    브라우저마다 사용하는 렌더링 엔진(HTML, CSS, JavaScript를 처리하는 엔진)이 다릅니다:
    - Chrome, Edge: Blink
    - Firefox: Gecko
    - Safari: WebKit
    D3.js는 DOM 요소와의 상호작용을 기반으로 동작하는데, 렌더링 엔진마다 이벤트 처리 방식이나 DOM 변경사항 반영 속도가 다를 수 있습니다.
    예를 들어, event.transform 같은 객체의 초기화 순서나, DOM 접근 방식의 미묘한 차이로 에러가 발생할 수 있습니다.

2. 브라우저의 기본 이벤트 처리 방식
    브라우저마다 기본적으로 처리하는 마우스 이벤트와 터치 이벤트가 다를 수 있습니다:
    Chrome은 터치 이벤트를 지원하지만, Firefox는 기본적으로 이를 비활성화할 수 있습니다.
    Safari는 특정 상황에서 pointer-events를 다르게 처리할 수 있습니다.
    D3.js에서 zoom 이벤트는 mousedown, mousemove, mouseup 이벤트와 결합됩니다. 특정 브라우저에서는 mousedown 시 이벤트 객체가 누락되어 e is null 문제가 발생할 수 있습니다.

3. D3.js와 브라우저의 호환성
    D3.js는 최신 브라우저와의 호환성을 유지하기 위해 업데이트됩니다. 그러나 브라우저의 버전 차이로 인해 일부 메서드나 속성이 다르게 동작할 수 있습니다.
    예시: D3의 d3.zoom()은 내부적으로 브라우저의 SVGElement.getBoundingClientRect()를 호출합니다. 브라우저마다 getBoundingClientRect()의 반환값이 다르게 구현되어 있을 수 있습니다.

4. CSS 스타일 적용 차이
    브라우저마다 CSS 스타일 규칙 적용 방식에 차이가 있습니다.
    예시: Safari와 Firefox는 SVG 요소에 transform 속성을 적용할 때 렌더링 순서가 Chrome과 다를 수 있습니다.
이로 인해 D3.js에서 transform을 기반으로 요소 크기와 위치를 계산하는 과정에서 문제가 발생할 수 있습니다.

5. D3.js 이벤트 객체 차이
    D3.js는 최신 브라우저 이벤트 객체를 사용하며, 브라우저가 이를 완벽히 지원하지 않으면 문제가 발생할 수 있습니다.
    일부 브라우저에서는 D3가 기대하는 이벤트 객체(event.transform 등)가 null로 전달되거나 누락될 수 있습니다.
